### PR TITLE
[ENHANCEMENT] Authenticatation in Apollo Client / Submit Post

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,5 +46,9 @@ module.exports = {
     "prettier/prettier": ["error", {}, { usePrettierrc: true }],
     camelcase: ["error"],
   },
+  globals: {
+    localStorage: true,
+    fetch: true,
+    window: true,
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,5 +44,7 @@ module.exports = {
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "prettier/prettier": ["error", {}, { usePrettierrc: true }],
+    camelcase: ["error"],
+  },
   },
 };

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -50,9 +50,7 @@ export default function Login() {
             }
           }
         `,
-        variables: {
-          input: credentials,
-        },
+        variables: { input: credentials },
       });
 
       setUser(login.user);

--- a/src/components/Sidenav.tsx
+++ b/src/components/Sidenav.tsx
@@ -6,7 +6,7 @@ import { BiBriefcase, BiNotepad } from "react-icons/bi";
 import { BsFillPersonFill } from "react-icons/bs";
 import { FiSettings } from "react-icons/fi";
 import { GoCommentDiscussion } from "react-icons/go";
-import { IoMdLogOut, IoMdLogIn } from "react-icons/io";
+import { IoMdLogOut } from "react-icons/io";
 import { useAuthenticatedUser } from "../hookes/useAuthenticatedUser";
 import { useJwt } from "../hookes/useJwt";
 
@@ -71,6 +71,7 @@ export const Sidenav = () => {
                 color="white"
                 fontSize="md"
                 fontWeight="medium"
+                isDisabled={!user}
                 px={6}
                 py={3}
                 mb={4}
@@ -86,6 +87,7 @@ export const Sidenav = () => {
                 color="white"
                 fontSize="md"
                 fontWeight="medium"
+                isDisabled={!user}
                 px={6}
                 py={3}
                 sx={{ textTransform: "uppercase" }}>

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from "react";
+import React, { createContext, useEffect, useState } from "react";
 
 interface AuthContextValue {
   accessToken: string;
@@ -10,14 +10,34 @@ interface AuthContextValue {
 export const AuthContext = createContext({} as AuthContextValue);
 
 export const AuthProvider = (props: any) => {
-  const [accessToken, setAccessToken] = useState("");
+  const [accessToken, _setAccessToken] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState("");
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const at = localStorage.getItem("token");
+      if (at) {
+        _setAccessToken(at);
+      }
+    }
+  }, [_setAccessToken]);
+
+  const setAccessToken = (token: string | null) => {
+    if (typeof window !== "undefined") {
+      if (token) {
+        localStorage.setItem("token", token);
+      } else {
+        localStorage.removeItem("token");
+      }
+    }
+    _setAccessToken(token);
+  };
 
   return (
     <AuthContext.Provider
       value={{
         accessToken,
-        setAccessToken: setAccessToken,
+        setAccessToken,
         refreshToken,
         setRefreshToken,
       }}

--- a/src/lib/apolloClient.ts
+++ b/src/lib/apolloClient.ts
@@ -1,14 +1,28 @@
 import { useMemo } from "react";
 import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client";
+import { setContext } from "@apollo/client/link/context";
 
 let apolloClient: ApolloClient<any>;
 
 function createApolloClient() {
+  const httpLink = new HttpLink({
+    uri: "http://localhost:4000/graphql",
+  });
+
+  const authLink = setContext((_, { headers }) => {
+    const token = localStorage.getItem("token");
+
+    return {
+      headers: {
+        ...headers,
+        authorization: token ? `Bearer ${token}` : null,
+      },
+    };
+  });
+
   return new ApolloClient({
     ssrMode: typeof window === "undefined", // set to true for SSR
-    link: new HttpLink({
-      uri: "http://localhost:4000/graphql",
-    }),
+    link: authLink.concat(httpLink),
     cache: new InMemoryCache(),
   });
 }


### PR DESCRIPTION
# Overview

Implement post submission via GQL mutation.

## Submit Post

Add submit functionality with `createPost` mutation, route back to index on submission.

## Apollo Client

Use `localStorage` token to authenticate logged-in user.

## Authentication

Route user back to `/login` route if not authenticated on `/forum/submit` page.

## Layout

Disable sidenav contribution buttons if not logged-in.