### PR TITLE
[ENHANCEMENT] Refresh Access Token

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -66,8 +66,12 @@ export default NextAuth({
       }
       return token;
     },
-    session: (session, token: any) => {
-      session.user = token.user;
+    // @ts-ignore
+    session: (session: WithAdditionalParams<Session>, token: JWT) => {
+      // don't include refresh token for security purposes
+      session.user = token.user as WithAdditionalParams<User>;
+      session.accessToken = token.accessToken as string;
+
       return session;
     },
   },

--- a/src/lib/apolloClient.ts
+++ b/src/lib/apolloClient.ts
@@ -16,8 +16,8 @@ function createApolloClient() {
     return {
       headers: {
         ...headers,
-        authorization: session?.user.accessToken
-          ? `Bearer ${session?.user.accessToken}`
+        authorization: session?.accessToken
+          ? `Bearer ${session?.accessToken}`
           : null,
       },
     };

--- a/src/lib/apolloClient.ts
+++ b/src/lib/apolloClient.ts
@@ -1,7 +1,7 @@
-import { useMemo } from "react";
 import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
-import { getSession } from "next-auth/client";
+import { getSession, signIn } from "next-auth/client";
+import { useMemo } from "react";
 
 let apolloClient: ApolloClient<any>;
 
@@ -11,7 +11,11 @@ function createApolloClient() {
   });
 
   const authLink = setContext(async (_, { headers }) => {
-    const session = await getSession();
+    const session = (await getSession()) as any;
+
+    if (session?.error === "RefreshAccessTokenError") {
+      signIn(); // Force sign in to hopefully resolve error
+    }
 
     return {
       headers: {

--- a/src/lib/refreshAccessToken.ts
+++ b/src/lib/refreshAccessToken.ts
@@ -1,0 +1,40 @@
+import { gql } from "@apollo/client";
+import { JWT } from "next-auth/jwt";
+import { initializeApollo } from "./apolloClient";
+
+export const refreshAccessToken = async ({ refreshToken, ...token }: JWT) => {
+  const apolloClient = initializeApollo();
+
+  try {
+    const {
+      data: { refreshToken: response },
+    } = await apolloClient.mutate({
+      mutation: gql`
+        mutation($input: RefreshTokenInput!) {
+          refreshToken(input: $input) {
+            accessToken
+            accessTokenExpiresAt
+          }
+        }
+      `,
+      variables: {
+        input: {
+          refreshToken,
+        },
+      },
+    });
+
+    return {
+      ...token,
+      ...response,
+      refreshToken,
+    };
+  } catch (error) {
+    console.error("Error:", error);
+    return {
+      ...token,
+      refreshToken,
+      error: "RefreshAccessTokenError",
+    };
+  }
+};


### PR DESCRIPTION
# Overview

Implement refresh access token flow for longer sessions.

## Server

 - Next-Auth.js session only exposes `user` and `accessToken` for improved security.
 - The token callback now checks for initial sign-in requests, as well as if the access token has expired, a refresh access token flow is initiated automatically.
 - GraphQL requests include the new `accessTokenExpiresAt` field and forego remapping return values.

## Client

 - Apollo Client checks if the session has refresh token errors and initiates the sign-in flow if the refresh token has expired.
 - `accessToken` for API is retrieved via `session.accessToken`.