### PR TITLE
[ENHANCEMENT/BUG] Sign-Up Page Callback URL / Yup Form Typing

### DIFF
--- a/pages/forum/submit.tsx
+++ b/pages/forum/submit.tsx
@@ -38,9 +38,7 @@ export default function Submit() {
 
   const onSubmit = async (data: any) => {
     try {
-      const {
-        data: { createPost },
-      } = await client.mutate({
+      await client.mutate({
         mutation: gql`
           mutation {
             createPost(input: { title: "test", body: "test" }) {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -11,12 +11,20 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { signIn } from "next-auth/client";
 import { useRouter } from "next/dist/client/router";
 import NextLink from "next/link";
+import * as React from "react";
 import { useForm } from "react-hook-form";
 import { GiOctopus } from "react-icons/gi";
 import * as yup from "yup";
 
 export default function Login() {
   const router = useRouter();
+  const callbackUrl = React.useMemo(
+    () =>
+      typeof router.query.callbackUrl == "string"
+        ? router.query.callbackUrl
+        : router.query.callbackUrl?.[0] ?? null,
+    [router],
+  );
 
   const schema = yup.object().shape({
     username: yup.string().required(),
@@ -26,7 +34,10 @@ export default function Login() {
     resolver: yupResolver(schema),
   });
 
-  const onSubmit = async ({ username, password }: any) => {
+  const onSubmit = async ({
+    username,
+    password,
+  }: yup.TypeOf<typeof schema>) => {
     const { error, ok } = await signIn("credentials", {
       username,
       password,
@@ -34,11 +45,7 @@ export default function Login() {
     });
 
     if (ok) {
-      router.push(
-        typeof router.query.callbackUrl == "string"
-          ? router.query.callbackUrl
-          : router.query.callbackUrl?.[0] ?? "/",
-      );
+      router.push(callbackUrl ?? "/");
     } else if (error) {
       setError("password", { message: error });
     }
@@ -78,7 +85,11 @@ export default function Login() {
               <Button type="submit" colorScheme="primary" mr={4}>
                 Login
               </Button>
-              <NextLink href="/signup" passHref>
+              <NextLink
+                href={
+                  callbackUrl ? `/signup?callbackUrl=${callbackUrl}` : "/signup"
+                }
+                passHref>
                 <Link colorScheme="secondary">Sign Up</Link>
               </NextLink>
             </form>

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -24,6 +24,13 @@ import * as yup from "yup";
 export default function SignUp() {
   const client = useApolloClient();
   const router = useRouter();
+  const callbackUrl = React.useMemo(
+    () =>
+      typeof router.query.callbackUrl == "string"
+        ? router.query.callbackUrl
+        : router.query.callbackUrl?.[0] ?? null,
+    [router],
+  );
 
   const schema = yup.object().shape({
     username: yup.string().required("Username is required"),
@@ -42,7 +49,10 @@ export default function SignUp() {
     mode: "onTouched",
   });
 
-  const onSubmit = async ({ username, password }: any) => {
+  const onSubmit = async ({
+    username,
+    password,
+  }: yup.TypeOf<typeof schema>) => {
     try {
       await client.mutate({
         mutation: gql`
@@ -69,11 +79,7 @@ export default function SignUp() {
       });
 
       if (ok) {
-        router.push(
-          router.query.callbackUrl == "string"
-            ? router.query.callbackUrl
-            : router.query.callbackUrl?.[0] ?? "/",
-        );
+        router.push(callbackUrl ?? "/");
       }
     } catch (error) {
       setError("username", { message: error.message, type: "validate" });
@@ -128,7 +134,11 @@ export default function SignUp() {
               <Button type="submit" colorScheme="primary" mr={4}>
                 Register
               </Button>
-              <NextLink href="/login" passHref>
+              <NextLink
+                href={
+                  callbackUrl ? `/login?callbackUrl=${callbackUrl}` : "/login"
+                }
+                passHref>
                 <Link colorScheme="secondary">Login</Link>
               </NextLink>
             </form>


### PR DESCRIPTION
Fixes #24.

# Overview

 - Add usage of `Yup.TypeOf<>` helper to add typing to form `onChange` handler.
 - Remove unused vars lint error.
 - Add `callbackUrl` to login and sign-up page links.